### PR TITLE
Demo: introduce ShellCheck violation

### DIFF
--- a/Backend/test/smoke_test.sh
+++ b/Backend/test/smoke_test.sh
@@ -89,7 +89,7 @@ test_shutdown() {
 
 demo_shellcheck_break() {
     local name="Sprint 7"
-    echo $name
+    echo "$name"
 }
 
 test_shutdown

--- a/Backend/test/smoke_test.sh
+++ b/Backend/test/smoke_test.sh
@@ -87,4 +87,10 @@ test_shutdown() {
   assert_contains "$calls" "ip link show wlan0"
 }
 
+demo_shellcheck_break() {
+    local name="Sprint 7"
+    echo $name
+}
+
 test_shutdown
+demo_shellcheck_break


### PR DESCRIPTION
Add a demonstration function that intentionally violates ShellCheck guidelines to illustrate potential issues in the script. This serves as an example for developers to identify and fix such violations.