### PR TITLE
Demo ShellCheck violation introduction

### DIFF
--- a/Backend/test/smoke_test.sh
+++ b/Backend/test/smoke_test.sh
@@ -89,7 +89,7 @@ test_shutdown() {
 
 demo_shellcheck_break() {
     local name="Sprint 7"
-    echo $name
+    echo "$name"
 }
 
 test_shutdown

--- a/Backend/test/smoke_test.sh
+++ b/Backend/test/smoke_test.sh
@@ -87,4 +87,10 @@ test_shutdown() {
   assert_contains "$calls" "ip link show wlan0"
 }
 
+demo_shellcheck_break() {
+    local name="Sprint 7"
+    echo $name
+}
+
 test_shutdown
+demo_shellcheck_break


### PR DESCRIPTION
Introduce a function that intentionally violates ShellCheck rules for demonstration purposes. This change serves as an example of a ShellCheck violation in the smoke test script.