### PR TITLE
GBSA-9477 - Fix multiple issues for a stable demo.

### DIFF
--- a/Backend/Cybercafe_daemon.sh
+++ b/Backend/Cybercafe_daemon.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 #Organization: Grey-box
 #Project: Cybercafe
 #File: daemon

--- a/Backend/Cybercafe_setupFunctions.sh
+++ b/Backend/Cybercafe_setupFunctions.sh
@@ -101,6 +101,7 @@ function setup_infrastructure
 	#check if iptmon_tx table exists
 	#this table will be used to record all transmitted data by adding rules for each user
 	iptables -t mangle -L iptmon_tx > /dev/null 2>> error.log
+        # shellcheck disable=SC2181
         if [[ $? -ne 0 ]]; then
                 iptables -t mangle -N iptmon_tx > /dev/null 2>> error.log
         fi
@@ -124,6 +125,7 @@ function setup_infrastructure
 	fi
 
         iptables -t mangle -C POSTROUTING -o "${HS_INTERFACE}" -j iptmon_rx > /dev/null 2>> error.log
+        # shellcheck disable=SC2181
         if [[ $? -ne 0 ]]; then
                 #if data is going out the hotspot interface (-o flag) and is not from the host itself then it will be forwared to iptmon_rx
                 iptables -t mangle -A POSTROUTING -o "${HS_INTERFACE}" -j iptmon_rx > /dev/null 2>> error.log
@@ -283,13 +285,13 @@ function shutdown_infrastructure
     # Remove Cybercafe filter FORWARD rules by comment
     iptables -t filter -S FORWARD 2>> error.log | grep 'cybercafe-block-' | while read -r rule; do
         del_rule="${rule/-A/-D}"
-        iptables -t filter $del_rule > /dev/null 2>> error.log || true
+        iptables -t filter "$del_rule" > /dev/null 2>> error.log || true
     done
 
     # Remove Cybercafe nat PREROUTING rules by comment
     iptables -t nat -S PREROUTING 2>> error.log | grep 'cybercafe-dnat' | while read -r rule; do
         del_rule="${rule/-A/-D}"
-        iptables -t nat $del_rule > /dev/null 2>> error.log || true
+        iptables -t nat "$del_rule" > /dev/null 2>> error.log || true
     done
 
         # 8) Reset runtime variables to safe defaults

--- a/Backend/Cybercafe_setupFunctions.sh
+++ b/Backend/Cybercafe_setupFunctions.sh
@@ -19,7 +19,7 @@ HS_STATUS_PREV='down'
 REFRESH_TIME=3600
 
 # Path to the file used to indicate the time we last did an expensive check of
-# the hotspot/CyberCafe infrastructure status. If the file doesn't exist, it's
+# the hotspot/CyberCafe infrastructure status. If the file doesnt exist, its
 # assumed we're not ready to act as a CyberCafe router.
 # Android Test
 # STATUS_PATH="/data/data/com.android.myapplication/files/tmp/cybercafe.confirmed"
@@ -93,33 +93,41 @@ function setup_infrastructure
 {
 	{
 		#trap will catch any errors that occur and write the line number to the error.log file
-		trap 'echo -e "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunction.sh: Line ${LINENO}\n" >> error.log' ERR
+		trap 'echo -e "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunctions.sh: Line ${LINENO}\n" >> error.log' ERR
 		#This will grab the ip address of the given hotspot interface so that it can be used for setup
 		LOCAL_IP=$(ifconfig "$HS_INTERFACE" | grep 'inet addr' | awk '{print $2}' | cut -d: -f2)
 	} > /dev/null 2>> error.log
 
 	#check if iptmon_tx table exists
 	#this table will be used to record all transmitted data by adding rules for each user
-	iptables -t mangle -C FORWARD -i "${HS_INTERFACE}" -j iptmon_tx > /dev/null 2>> error.log
+	iptables -t mangle -L iptmon_tx > /dev/null 2>> error.log
+        if [[ $? -ne 0 ]]; then
+                iptables -t mangle -N iptmon_tx > /dev/null 2>> error.log
+        fi
+
+        iptables -t mangle -C FORWARD -i "${HS_INTERFACE}" -j iptmon_tx > /dev/null 2>> error.log
 	# shellcheck disable=SC2181
 	if [[ $? -ne 0 ]]; then
-		create_chain "setup_infrastructure" "iptmon_tx"
 		#packets that come in on the hotspot interface (-i flag) and are destined for a different host than the hotspot host will be forwarded to iptmon_tx
 		iptables -t mangle -A FORWARD -i "${HS_INTERFACE}" -j iptmon_tx > /dev/null 2>> error.log
 	fi
 
 	#create iptmon_rx
-	iptables -t mangle -C POSTROUTING -o "${HS_INTERFACE}" -j iptmon_rx > /dev/null 2>> error.log
+	iptables -t mangle -L iptmon_rx > /dev/null 2>> error.log
 	# shellcheck disable=SC2181
 	if [[ $? -ne 0 ]]; then
 		{
 			iptables -t mangle -N iptmon_rx
 			#if data is coming from the host itself then don't count it towards the rx total
 			iptables -t mangle -I iptmon_rx 1 -s "${LOCAL_IP}" -j RETURN
-			# if data is going out the hotspot interface (-o flag) and is not from the host itself then it will be forwarded to iptmon_rx
-			iptables -t mangle -A POSTROUTING -o "${HS_INTERFACE}" -j iptmon_rx
 		} > /dev/null 2>> error.log
 	fi
+
+        iptables -t mangle -C POSTROUTING -o "${HS_INTERFACE}" -j iptmon_rx > /dev/null 2>> error.log
+        if [[ $? -ne 0 ]]; then
+                #if data is going out the hotspot interface (-o flag) and is not from the host itself then it will be forwared to iptmon_rx
+                iptables -t mangle -A POSTROUTING -o "${HS_INTERFACE}" -j iptmon_rx > /dev/null 2>> error.log
+        fi
 
 	#special rules that service the cybercafe system by blocking certain traffic over hotspot interface
 	iptables -t nat -C PREROUTING -p tcp -i "${HS_INTERFACE}" -j DNAT --to-destination "${LOCAL_IP}:80" > /dev/null 2>> error.log #checks to see that rules don't exist
@@ -129,7 +137,9 @@ function setup_infrastructure
 			#redirects all tcp traffic to captive webserver port so that 'sign-in' notification is displayed to user when device does http checks
 			#also blocks typically web navigation
 			#Note: Since the protocol is tcp it won't mess up any important DNS or other services
-			iptables -t nat -I PREROUTING 1 -p tcp -i "${HS_INTERFACE}" -j DNAT --to-destination "${LOCAL_IP}:80"
+			iptables -t nat -I PREROUTING 1 -p tcp -i "${HS_INTERFACE}" \
+                          -m comment --comment "cybercafe-dnat" \
+                          -j DNAT --to-destination "${LOCAL_IP}:80"
 		
 			#deprecated rules
 			##safeguard: allows solicitation to DNS server (note this will show up as rule #2 on PREROUTING if uncommeneted)
@@ -139,15 +149,19 @@ function setup_infrastructure
 			#
 		
 			#blocks requests incoming on the hotspot interface that is not destined for the hotspot host (exceptions will be made on a user basis once they sign in)
-			iptables -t filter -I FORWARD 1 -p all -i "${HS_INTERFACE}" -j DROP
+			iptables -t filter -I FORWARD 1 -p all -i "${HS_INTERFACE}" \
+                          -m comment --comment "cybercafe-block-in" \
+                          -j DROP
 			#in the uncommon event that traffic going out onto the hotspot interface that isn't from the host (exceptions will be made on a user basis once they sign in)
-			iptables -t filter -I FORWARD 1 -p all -o "${HS_INTERFACE}" ! -s "${LOCAL_IP}" -j DROP
+			iptables -t filter -I FORWARD 1 -p all -o "${HS_INTERFACE}" ! -s "${LOCAL_IP}" \
+                          -m comment --comment "cybercafe-block-out" \
+                          -j DROP
 		} > /dev/null 2>> error.log
 	fi
 
 	# Ensure captive portal HTTPD server is running
 	if ! start_captive_webserver; then
-		echo "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunction.sh: Line '${LINENO}' - Failed to start captive webserver" >> error.log
+		echo "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunctions.sh: Line '${LINENO}' - Failed to start captive webserver" >> error.log
 	fi
 }
 
@@ -156,7 +170,7 @@ function shutdown_infrastructure
 #remove any necessary infrastructure for running the CyberCafe system
 {
     # preserve existing trap / error logging
-	trap 'echo -e "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunction.sh: Line '${LINENO}' \n" >> error.log' ERR > /dev/null 2>> error.log
+	trap 'echo -e "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunctions.sh: Line '${LINENO}' \n" >> error.log' ERR > /dev/null 2>> error.log
 
     # dry-run support (export DRY_RUN=true to simulate)
     DRY_RUN=${DRY_RUN:-false}
@@ -265,7 +279,20 @@ function shutdown_infrastructure
       warn "tc not found; skipping qdisc cleanup"
     fi
 
-	# 7) Reset runtime variables to safe defaults
+	# 7) Remove all commented Cybercafe rules
+    # Remove Cybercafe filter FORWARD rules by comment
+    iptables -t filter -S FORWARD 2>> error.log | grep 'cybercafe-block-' | while read -r rule; do
+        del_rule="${rule/-A/-D}"
+        iptables -t filter $del_rule > /dev/null 2>> error.log || true
+    done
+
+    # Remove Cybercafe nat PREROUTING rules by comment
+    iptables -t nat -S PREROUTING 2>> error.log | grep 'cybercafe-dnat' | while read -r rule; do
+        del_rule="${rule/-A/-D}"
+        iptables -t nat $del_rule > /dev/null 2>> error.log || true
+    done
+
+        # 8) Reset runtime variables to safe defaults
     export LOCAL_IP=''
     export HS_STATUS='down'
     export HS_STATUS_PREV='down'
@@ -278,17 +305,17 @@ function start_captive_webserver
 {
 	#Make sure required variables are set
 	if [ -z "${LIGHTTPD_PATH:-}" ] || [ -z "${LIGHTTPD_CONF:-}" ]; then
-		echo "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunction.sh: Line ${LINENO} - LIGHTTPD_PATH or LIGHTTPD_CONF_PATH variable not set" >> error.log
+		echo "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunctions.sh: Line ${LINENO} - LIGHTTPD_PATH or LIGHTTPD_CONF_PATH variable not set" >> error.log
 		return 1
 	fi
 
 	#Make sure paths are valid
 	if [ ! -x "${LIGHTTPD_PATH}" ]; then
-		echo "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunction.sh: Line ${LINENO} - lighttpd executable not found at LIGHTTPD_PATH: ${LIGHTTPD_PATH}" >> error.log
+		echo "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunctions.sh: Line ${LINENO} - lighttpd executable not found at LIGHTTPD_PATH: ${LIGHTTPD_PATH}" >> error.log
 		return 1
 	fi
 	if [ ! -f "${LIGHTTPD_CONF}" ]; then
-		echo "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunction.sh: Line ${LINENO} - lighttpd configuration file not found at LIGHTTPD_CONF_PATH: ${LIGHTTPD_CONF}" >> error.log
+		echo "$(date '+%Y-%m-%dT%H:%M:%S%z') Error in Cybercafe_setupFunctions.sh: Line ${LINENO} - lighttpd configuration file not found at LIGHTTPD_CONF_PATH: ${LIGHTTPD_CONF}" >> error.log
 		return 1
 	fi
 

--- a/Backend/cybercafe.conf
+++ b/Backend/cybercafe.conf
@@ -1,8 +1,9 @@
-DATABASE_PATH="/data/data/com.termux/files/usr/var/www/database/CyberCafe_Database.db"
+DATABASE_PATH="/data/data/com.termux/files/home/Project_Cybercafe/Database/CyberCafe_Database.db"
 #path to lighttpd software
 LIGHTTPD_PATH="/data/data/com.termux/files/usr/bin/lighttpd"
+LIGHTTPD_CONF="/data/data/com.termux/files/home/Project_Cybercafe/Backend/lighttpd.conf"
 # Interface of the hotspot
-HS_INTERFACE='wlan1'
+HS_INTERFACE='wlan0'
 #Maximum time that a session can exist in seconds
 SESSION_MAX_AGE=43200
 #Maximum time that a session can be idle in seconds

--- a/Backend/cybercafe.conf
+++ b/Backend/cybercafe.conf
@@ -1,7 +1,9 @@
-DATABASE_PATH="/data/data/com.termux/files/home/Project_Cybercafe/Database/CyberCafe_Database.db"
+BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT_PATH="$(cd "$BASE_PATH/.." && pwd)"
+DATABASE_PATH="$PROJECT_ROOT_PATH/Database/CyberCafe_Database.db"
 #path to lighttpd software
 LIGHTTPD_PATH="/data/data/com.termux/files/usr/bin/lighttpd"
-LIGHTTPD_CONF="/data/data/com.termux/files/home/Project_Cybercafe/Backend/lighttpd.conf"
+LIGHTTPD_CONF="$BASE_PATH/lighttpd.conf"
 # Interface of the hotspot
 HS_INTERFACE='wlan0'
 #Maximum time that a session can exist in seconds

--- a/Backend/cybercafe.sh
+++ b/Backend/cybercafe.sh
@@ -1,11 +1,12 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/bash
 #Organization: Grey-box
 #Project: Cybercafe
 #File: Control File
 #Description: Acts as the interface between the administrator/developer and the Cybercafe backend.
 
 ##VARIABLES##
-BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_PATH="/data/data/com.termux/files/home/Project_Cybercafe/Backend"
+UTIL_PATH="/data/data/com.termux/files/usr/bin"
 
 ##INCLUDES##
 . "$BASE_PATH/cybercafe.conf"
@@ -17,14 +18,14 @@ function command_run
 {
 	#test to see if daemon is already running
 	# shellcheck disable=SC2009
-	ps -eo name,cmdline | grep "bash ${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep > /dev/null 2>&1 # if this returns 0 it implies that the script exists and is running
+	ps -eo name,cmdline | grep "${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep > /dev/null 2>&1 # if this returns 0 it implies that the script exists and is running
 	# shellcheck disable=SC2181
 	if [[ $? -eq 0 ]]; then
 		echo "Cybercafe infrastructure already running."
 	else
         printf "%s" "$(date +%T)" \
 		&& echo " Running Cybercafe..."
-		nohup bash $BASE_PATH/Cybercafe_daemon.sh & #run CyberCafe daemon as a seperate process
+		nohup $UTIL_PATH/bash "$BASE_PATH/Cybercafe_daemon.sh" & #run CyberCafe daemon as a seperate process
         printf "%s" "$(date +%T)" \
         && echo " Cybercafe started."
 		
@@ -43,7 +44,7 @@ function command_status
     printf "%s" "$(date '+%Y-%m-%d %H:%M:%S')"
 	echo ""
 	# shellcheck disable=SC2009
-	ps -eo name,cmdline | grep "bash ${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep > /dev/null 2>&1 # if this returns 0 it implies that the script exists and is running
+	ps -eo name,cmdline | grep "${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep > /dev/null 2>&1 # if this returns 0 it implies that the script exists and is running
 	# shellcheck disable=SC2181
 	if [[ $? -eq 0 ]]; then
 		echo "Status: Running"
@@ -52,7 +53,7 @@ function command_status
 		# shellcheck disable=SC2009
 		ps -o user,pid,ppid,uid,stime,stat,name,cmdline | head -n 1
 		# shellcheck disable=SC2009
-		ps -eo user,pid,ppid,uid,stime,stat,name,cmdline | grep "bash ${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep
+		ps -eo user,pid,ppid,uid,stime,stat,name,cmdline | grep "${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep
 	else
 		echo "Status: Stopped"
 	fi
@@ -114,7 +115,7 @@ function command_errorlog
 function command_shutdown
 {
 	# shellcheck disable=SC2009
-	ps -eo stat,name,cmdline | grep "bash ${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep > /dev/null 2>&1 # if this returns 0 it implies that the script exists and is running
+	ps -eo stat,name,cmdline | grep "${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep > /dev/null 2>&1 # if this returns 0 it implies that the script exists and is running
 	# shellcheck disable=SC2181
 	if [[ $? -eq 0 ]]; then
 		printf "%s" "$(date +%T)"
@@ -124,7 +125,7 @@ function command_shutdown
 		while true; do
 			sleep 1
 			# shellcheck disable=SC2009
-			ps -eo stat,name,cmdline | grep "bash ${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep > /dev/null 2>&1 # if this returns 1 it implies that the script has stopped
+			ps -eo stat,name,cmdline | grep "${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep > /dev/null 2>&1 # if this returns 1 it implies that the script has stopped
 			# shellcheck disable=SC2181
 			if [[ $? -eq 1 ]]; then
 				rm shutdown.confirmed
@@ -140,7 +141,7 @@ function command_shutdown
 
 function command_kill
 {
-	killall -9 Cybercafe_daemon.sh
+	pkill -f "$BASE_PATH/Cybercafe_daemon.sh"
 	clear_internet_sessions
 	shutdown_infrastructure
 }

--- a/Backend/cybercafe.sh
+++ b/Backend/cybercafe.sh
@@ -5,8 +5,9 @@
 #Description: Acts as the interface between the administrator/developer and the Cybercafe backend.
 
 ##VARIABLES##
-BASE_PATH="/data/data/com.termux/files/home/Project_Cybercafe/Backend"
+BASE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UTIL_PATH="/data/data/com.termux/files/usr/bin"
+
 
 ##INCLUDES##
 . "$BASE_PATH/cybercafe.conf"
@@ -17,6 +18,10 @@ UTIL_PATH="/data/data/com.termux/files/usr/bin"
 function command_run
 {
 	#test to see if daemon is already running
+
+        echo "==== DEBUG PATH CHECK ===="
+        echo "Absolute path: $BASE_PATH"
+
 	# shellcheck disable=SC2009
 	ps -eo name,cmdline | grep "${BASE_PATH}/Cybercafe_daemon.sh" | grep -v grep > /dev/null 2>&1 # if this returns 0 it implies that the script exists and is running
 	# shellcheck disable=SC2181

--- a/Backend/lighttpd.conf
+++ b/Backend/lighttpd.conf
@@ -19,12 +19,13 @@ include conf_dir + "/conf.d/fastcgi.conf"
 
 
 #Basic Configuration
-server.document-root = server_root + "/htdocs/"
-index-file.names = ( "page.html", "page.php" )
+#server.document-root = server_root + "/htdocs/"
+server.document-root = "/data/data/com.termux/files/home/Project_Cybercafe"
+index-file.names = ( "index.php" )
 #server.bind = "localhost"
 server.port = 80
-server.username = "u0_a234"
-server.groupname = "u0_a234"
+#server.username = "u0_a234"
+#server.groupname = "u0_a234"
 
 
 #File Config
@@ -38,14 +39,27 @@ server.max-fds = 16384
 url.access-deny = ( "~", ".inc" )
 static-file.exclude-extensions = ( ".fcgi", ".rb", "~", ".inc" )
 
+#Needed to load php instead of push php files
+fastcgi.server += ( ".php" =>
+  ((
+    "bin-path" => "/data/data/com.termux/files/usr/bin/php-cgi",
+    "socket" => "/data/data/com.termux/files/usr/tmp/php.socket",
+    "max-procs" => 1,
+    "bin-environment" => (
+      "PHP_FCGI_CHILDREN" => "1",
+      "PHP_FCGI_MAX_REQUESTS" => "1000"
+    )
+  ))
+)
+
 #This variables need to be dynamically updated (automation for this still needs to be added)
-var.allowedHostIPs = "10\.18\.120\.52|192\.168\.1\.131|127\.0\.0\.1"
-var.hotspotNetwork = "10.18.120.0/24"
+var.allowedHostIPs = "10\.18\.120\.52|192\.168\.43\.79|127\.0\.0\.1"
+var.hotspotNetwork = "192.168.43.0/24"
 
 #Redirect HTTP traffic to webserver index page
 #this is necessary for captive portal functionallity since iptables will redirect all hotspot traffic to lighttpd
 $HTTP["host"] !~ allowedHostIPs {
 	$HTTP["remoteip"] == hotspotNetwork {
-		url.redirect = ("" => "http://10.18.120.52/")
+		url.redirect = ("" => "http://192.168.43.79/")
 	}
 }

--- a/Backend/test/utils/net_helpers.sh
+++ b/Backend/test/utils/net_helpers.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 create_chain() {
-    echo "iptables -t mangle -N $2"
+    iptables -t mangle -N "$2"
 }
 
 add_rule() {


### PR DESCRIPTION
PHP files were being downloaded instead of executed when using the Backend lighttpd config.

Root cause:
FastCGI was not properly configured in Backend/lighttpd.conf.

Fix:
Added explicit fastcgi.server block pointing to php-cgi.

Now:
- PHP executes correctly
- captive portal loads Website UI
- guest login page displays on device

Note:
This was tested on the T95 device with hotspot + iptables redirect.